### PR TITLE
Create unique subnets

### DIFF
--- a/rds/rds_provider.go
+++ b/rds/rds_provider.go
@@ -67,7 +67,7 @@ func (r *RDS) ensureSubnets(db *crd.Database) (string, error) {
 		log.Println("Error: unable to continue due to lack of subnets, perhaps we couldn't lookup the subnets")
 	}
 	subnetDescription := "subnet for " + db.Name + " in namespace " + db.Namespace
-	subnetName := db.Name + "-subnet"
+	subnetName := db.Name + "-subnet-" + db.Namespace
 
 	svc := r.rdsclient()
 


### PR DESCRIPTION
We should have a unique name for subnets. That way it wont
fail if we create multiple databases