### PR TITLE
Enable delete protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ spec:
   username: postgres # Database username
   size: 10 # size in BG
   backupretentionperiod: 10 # days to keep backup, 0 means diable
+  deleteprotection: true # don't delete the database even though the object is delete in k8s
   encrypted: true # should the database be encrypted
   iops: 1000 # number of iops
   multiaz: true # multi AZ support

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -1,7 +1,7 @@
 package crd
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -63,6 +63,7 @@ type DatabaseSpec struct {
 	StorageType           string               `json:"storagetype,omitempty"`
 	Iops                  int64                `json:"iops,omitempty"`
 	BackupRetentionPeriod int64                `json:"backupretentionperiod,omitempty"` // between 0 and 35, zero means disable
+	DeleteProtection      bool                 `json:"deleteprotection,omitempty"`
 }
 
 type DatabaseStatus struct {

--- a/db.yaml
+++ b/db.yaml
@@ -16,6 +16,7 @@ spec:
   engine: postgres
   dbname: thepgsql
   name: thatpgsql
+  deleteprotection: false
   password:
     key: mykey
     name: mysecret

--- a/rds/rds_provider.go
+++ b/rds/rds_provider.go
@@ -142,6 +142,10 @@ func getEndpoint(dbName *string, svc *rds.RDS) (string, error) {
 }
 
 func (r *RDS) DeleteDatabase(db *crd.Database) error {
+	if db.Spec.DeleteProtection {
+		log.Printf("Trying to delete a %v in %v which is a deleted protected database", db.Name, db.Namespace)
+		return nil
+	}
 	// delete the database instance
 	svc := r.rdsclient()
 	res := svc.DeleteDBInstanceRequest(&rds.DeleteDBInstanceInput{


### PR DESCRIPTION
Enables us to not delete the database even though the Kubernetes
database object is deleted.