### PR TITLE
Adding support for custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ spec:
   iops: 1000 # number of iops
   multiaz: true # multi AZ support
   storagetype: gp2 # type of the underlying storage
+  tags: "key=value,key1=value1"
  
 ```
 

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -45,69 +45,73 @@ func NewDatabaseCRD() *apiextv1beta1.CustomResourceDefinition {
 				OpenAPIV3Schema: &apiextv1beta1.JSONSchemaProps{
 					Type: "object",
 					Properties: map[string]apiextv1beta1.JSONSchemaProps{
-						"spec": apiextv1beta1.JSONSchemaProps{
+						"spec": {
 							Type: "object",
 							Properties: map[string]apiextv1beta1.JSONSchemaProps{
-								"username": apiextv1beta1.JSONSchemaProps{
+								"username": {
 									Type:        "string",
 									Description: "User Name to access the database",
 									MinLength:   intptr(1),
 									MaxLength:   intptr(16),
 									Pattern:     DBUsernamePattern,
 								},
-								"dbname": apiextv1beta1.JSONSchemaProps{
+								"dbname": {
 									Type:        "string",
 									Description: "Database name",
 									MinLength:   intptr(1),
 									MaxLength:   intptr(63),
 									Pattern:     DBNamePattern,
 								},
-								"engine": apiextv1beta1.JSONSchemaProps{
+								"engine": {
 									Type:        "string",
 									Description: "database engine. Ex: postgres, mysql, aurora-postgresql, etc",
 								},
-								"class": apiextv1beta1.JSONSchemaProps{
+								"class": {
 									Type:        "string",
 									Description: "instance class name. Ex: db.m5.24xlarge or db.m3.medium",
 								},
-								"size": apiextv1beta1.JSONSchemaProps{
+								"size": {
 									Type:        "integer",
 									Description: "Database size in Gb",
 									Minimum:     floatptr(20),
 									Maximum:     floatptr(64000),
 								},
-								"multiaz": apiextv1beta1.JSONSchemaProps{
+								"multiaz": {
 									Type:        "boolean",
 									Description: "should it be available in multiple regions?",
 								},
-								"publiclyaccessible": apiextv1beta1.JSONSchemaProps{
+								"publiclyaccessible": {
 									Type:        "boolean",
 									Description: "is the database publicly accessible?",
 								},
-								"storageencrypted": apiextv1beta1.JSONSchemaProps{
+								"storageencrypted": {
 									Type:        "boolean",
 									Description: "should the storage be encrypted?",
 								},
-								"storagetype": apiextv1beta1.JSONSchemaProps{
+								"storagetype": {
 									Type:        "string",
 									Description: "gp2 (General Purpose SSD) or io1 (Provisioned IOPS SSD)",
 									Pattern:     StorageTypePattern,
 								},
-								"iops": apiextv1beta1.JSONSchemaProps{
+								"iops": {
 									Type:        "integer",
 									Description: "I/O operations per second",
 									Minimum:     floatptr(1000),
 									Maximum:     floatptr(80000),
 								},
-								"backupretentionperiod": apiextv1beta1.JSONSchemaProps{
+								"backupretentionperiod": {
 									Type:        "integer",
 									Description: "Retention period in days. 0 means disabled, 7 is the default and 35 is the maximum",
 									Minimum:     floatptr(0),
 									Maximum:     floatptr(35),
 								},
-								"deleteprotection": apiextv1beta1.JSONSchemaProps{
+								"deleteprotection": {
 									Type:        "boolean",
 									Description: "Enable or disable deletion protection",
+								},
+								"tags": {
+									Type:        "string",
+									Description: "Tags to create on the database instance format key=value,key1=value1",
 								},
 							},
 						},
@@ -151,6 +155,7 @@ type DatabaseSpec struct {
 	Iops                  int64                `json:"iops,omitempty"`
 	BackupRetentionPeriod int64                `json:"backupretentionperiod,omitempty"` // between 0 and 35, zero means disable
 	DeleteProtection      bool                 `json:"deleteprotection,omitempty"`
+	Tags                  string               `json:"tags,omitempty"` // key=value,key1=value1
 }
 
 type DatabaseStatus struct {
@@ -183,7 +188,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	return nil
 }
 
-// Create a Rest client with the new CRD Schema
+// NewClient Creates a Rest client with the new CRD Schema
 func NewClient(cfg *rest.Config) (*rest.RESTClient, *runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 	SchemeBuilder := runtime.NewSchemeBuilder(addKnownTypes)

--- a/db.yaml
+++ b/db.yaml
@@ -22,3 +22,4 @@ spec:
     name: mysecret
   username: postgres
   size: 10
+  tags: "environment=test,team=backend"

--- a/rds/rds_provider.go
+++ b/rds/rds_provider.go
@@ -233,9 +233,22 @@ func toTags(annotations, labels map[string]string) []rds.Tag {
 	return tags
 }
 
-func convertSpecToInput(v *crd.Database, subnetName string, securityGroups []string, password string) *rds.CreateDBInstanceInput {
+func gettags(db *crd.Database) []rds.Tag {
+	tags := []rds.Tag{}
+	if db.Spec.Tags == "" {
+		return tags
+	}
+	for _, v := range strings.Split(db.Spec.Tags, ",") {
+		kv := strings.Split(v, "=")
 
+		tags = append(tags, rds.Tag{Key: aws.String(strings.TrimSpace(kv[0])), Value: aws.String(strings.TrimSpace(kv[1]))})
+	}
+	return tags
+}
+
+func convertSpecToInput(v *crd.Database, subnetName string, securityGroups []string, password string) *rds.CreateDBInstanceInput {
 	tags := toTags(v.Annotations, v.Labels)
+	tags = append(tags, gettags(v)...)
 
 	input := &rds.CreateDBInstanceInput{
 		DBName:                aws.String(v.Spec.DBName),

--- a/rds/rds_provider_test.go
+++ b/rds/rds_provider_test.go
@@ -40,7 +40,7 @@ func TestConvertSpecToInput(t *testing.T) {
 	assert.Equal(t, int64(1000), *i.Iops)
 }
 
-func TestgetIDFromProvider(t *testing.T) {
+func TestGetIDFromProvider(t *testing.T) {
 	x := getIDFromProvider("aws:///eu-west-1a/i-02ab67f4da79c3caa")
 	assert.Equal(t, "i-02ab67f4da79c3caa", x)
 }
@@ -123,4 +123,35 @@ func TestToTags(t *testing.T) {
 		}
 
 	}
+}
+
+func TestTags(t *testing.T) {
+	db := &crd.Database{
+		Spec: crd.DatabaseSpec{
+			Tags: "key=value,key1=value1",
+		},
+	}
+	tags := gettags(db)
+	assert.NotNil(t, tags)
+	assert.Equal(t, 2, len(tags))
+	assert.Equal(t, "key", *tags[0].Key)
+	assert.Equal(t, "value", *tags[0].Value)
+	assert.Equal(t, "key1", *tags[1].Key)
+	assert.Equal(t, "value1", *tags[1].Value)
+
+}
+func TestTagsWithSpaces(t *testing.T) {
+	db := &crd.Database{
+		Spec: crd.DatabaseSpec{
+			Tags: "key= value,   key1=value1",
+		},
+	}
+	tags := gettags(db)
+	assert.NotNil(t, tags)
+	assert.Equal(t, 2, len(tags))
+	assert.Equal(t, "key", *tags[0].Key)
+	assert.Equal(t, "value", *tags[0].Value)
+	assert.Equal(t, "key1", *tags[1].Key)
+	assert.Equal(t, "value1", *tags[1].Value)
+
 }


### PR DESCRIPTION
You can now in the spec add custom tags, that will be propagated to the RDS instance
This fixes #33 