### PR TITLE
Set Deployment strategy on local provider to Recreate

### DIFF
--- a/local/local_provider.go
+++ b/local/local_provider.go
@@ -231,6 +231,9 @@ func toSpec(db *crd.Database, repository string) v1.DeploymentSpec {
 				"db": db.Name,
 			},
 		},
+		Strategy: v1.DeploymentStrategy{
+		    Type: "Recreate",
+		},
 		Template: corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{


### PR DESCRIPTION
This commit sets deployment strategy type on local provider to Recreate.
When we are using local provider a new deployment object is created
for each database CRD found in cluster which has these deployment
strategy by default:
```
strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
```
With this strategy a new pod is started and is waiting
to become up and ready which is not possible since is waiting
for the same EBS volume used by the old pod to be mounted
on the new pod.
By using type: Recreate the old pod is terminated and thus its
EBS volume can be mounted and used by the new pod.
Without this change we end up with a bunch of pods stuck in
ContainerCreating phase and waiting for EBS volume
to be mounted.