### PR TITLE
Restore DB instance from existing snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,28 @@ State: BETA - use with caution
 
 The node running the pod should have an instance profile that allows creation and deletion of RDS databases and Subnets.
 
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSubnets",
+                "rds:CreateDBSubnetGroup",
+                "rds:DeleteDBSubnetGroup",
+                "rds:AddTagsToResource",
+                "rds:DescribeDBInstances",
+                "rds:CreateDBInstance",
+                "rds:ModifyDBInstance",
+                "rds:DeleteDBInstance"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
 The codes will search for the first node, and take the subnets from that node. And depending on wether or not your DB should be public, then filter them on that. If any subnets left it will attach the DB to that.
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ spec:
   tags: "key=value,key1=value1"
   provider: aws # Optional either aws or local, will overrides the value the operator was started with 
   skipfinalsnapshot: false # Indicates whether to skip the creation of a final DB snapshot before deleting the instance. By default, skipfinalsnapshot isn't enabled, and the DB snapshot is created.
+  ApplyImmediately: true # When you modify a DB instance, you can apply the changes immediately by setting the ApplyImmediately parameter to true. If you don't choose to apply changes immediately, the changes are put into the pending modifications queue. During the next maintenance window, any pending changes in the queue are applied. If you choose to apply changes immediately, your new changes and any changes in the pending modifications queue are applied. 
   
 ```
 

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -182,6 +182,7 @@ type DatabaseSpec struct {
 	Provider              string               `json:"provider,omitempty"` // local or aws
 	SkipFinalSnapshot     bool                 `json:"skipfinalsnapshot,omitempty"`
 	ApplyImmediately      bool                 `json:"ApplyImmediately,omitempty"`
+	DBSnapshotIdentifier  string               `json:"DBSnapshotIdentifier,omitempty"`
 }
 
 type DatabaseStatus struct {

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -129,6 +129,10 @@ func NewDatabaseCRD() *apiextv1beta1.CustomResourceDefinition {
 									Type:        "boolean",
 									Description: "Indicates whether to skip the creation of a final DB snapshot before deleting the instance. By default, skipfinalsnapshot isn't enabled, and the DB snapshot is created.",
 								},
+								"ApplyImmediately": {
+									Type:        "boolean",
+									Description: "When you modify a DB instance, you can apply the changes immediately by setting the ApplyImmediately parameter to true. If you don't choose to apply changes immediately, the changes are put into the pending modifications queue. During the next maintenance window, any pending changes in the queue are applied. If you choose to apply changes immediately, your new changes and any changes in the pending modifications queue are applied. ",
+								},
 							},
 						},
 					},
@@ -177,6 +181,7 @@ type DatabaseSpec struct {
 	Tags                  string               `json:"tags,omitempty"`     // key=value,key1=value1
 	Provider              string               `json:"provider,omitempty"` // local or aws
 	SkipFinalSnapshot     bool                 `json:"skipfinalsnapshot,omitempty"`
+	ApplyImmediately      bool                 `json:"ApplyImmediately,omitempty"`
 }
 
 type DatabaseStatus struct {

--- a/local/local_provider.go
+++ b/local/local_provider.go
@@ -29,6 +29,11 @@ func New(db *crd.Database, kc kubernetes.Interface, repository string) (*Local, 
 	return &r, nil
 }
 
+func (l *Local) UpdateDatabase(ctx context.Context, db *crd.Database) error {
+	_, err := l.CreateDatabase(ctx, db)
+	return err
+}
+
 // CreateDatabase creates a database from the CRD database object, is also ensures that the correct
 // subnets are created for the database so we can access it
 func (l *Local) CreateDatabase(ctx context.Context, db *crd.Database) (string, error) {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/sorenmat/k8s-rds/crd"
 )
 
@@ -9,6 +10,7 @@ import (
 // this is the main interface that should be implemented if a new provider is created
 type DatabaseProvider interface {
 	CreateDatabase(context.Context, *crd.Database) (string, error)
+	UpdateDatabase(context.Context, *crd.Database) error
 	DeleteDatabase(context.Context, *crd.Database) error
 	ServiceProvider
 }

--- a/rds/rds_provider.go
+++ b/rds/rds_provider.go
@@ -114,6 +114,33 @@ func (r *RDS) CreateDatabase(ctx context.Context, db *crd.Database) (string, err
 	return dbHostname, nil
 }
 
+func (r *RDS) UpdateDatabase(ctx context.Context, db *crd.Database) error {
+	input := convertSpecToModifyInput(db)
+
+	log.Printf("Trying to find db instance %v to update\n", db.Spec.DBName)
+	k := &rds.DescribeDBInstancesInput{DBInstanceIdentifier: input.DBInstanceIdentifier}
+	_, err := r.rdsclient().DescribeDBInstances(ctx, k)
+
+	if err == nil {
+		log.Printf("DB instance %v found trying to update it\n", db.Spec.DBName)
+		_, err := r.rdsclient().ModifyDBInstance(ctx, input)
+		if err != nil {
+			log.Printf("Updating database failed: ModifyDBInstance:%v\n", err)
+			return errors.Wrap(err, "ModifyDBInstance")
+		}
+	} else {
+		return errors.Wrap(err, fmt.Sprintf("wasn't able to describe the db instance with id %v", input.DBInstanceIdentifier))
+	}
+
+	if input.ApplyImmediately {
+		log.Printf("Database modified and will be updated immediately")
+	} else {
+		log.Printf("Database modified and update is pending and will be executed during the next maintenance window")
+	}
+
+	return nil
+}
+
 // ensureSubnets is ensuring that we have created or updated the subnet according to the data from the CRD object
 func (r *RDS) ensureSubnets(ctx context.Context, db *crd.Database) (string, error) {
 	if len(r.Subnets) == 0 {
@@ -153,7 +180,9 @@ func getEndpoint(ctx context.Context, dbName *string, svc *rds.Client) (string, 
 		return "", fmt.Errorf("wasn't able to describe the db instance with id %v", dbName)
 	}
 	rdsdb := instance.DBInstances[0]
-
+	if rdsdb.Endpoint == nil || rdsdb.Endpoint.Address == nil {
+		return "", fmt.Errorf("couldn't get the endpoint for DB instance with id %v", dbName)
+	}
 	dbHostname := *rdsdb.Endpoint.Address
 	return dbHostname, nil
 }
@@ -294,6 +323,30 @@ func convertSpecToInput(v *crd.Database, subnetName string, securityGroups []str
 	return input
 }
 
+func convertSpecToModifyInput(v *crd.Database) *rds.ModifyDBInstanceInput {
+	input := &rds.ModifyDBInstanceInput{
+		AllocatedStorage:      aws.Int32(int32(v.Spec.Size)),
+		MaxAllocatedStorage:   aws.Int32(int32(v.Spec.MaxAllocatedSize)),
+		DBInstanceClass:       aws.String(v.Spec.Class),
+		ApplyImmediately:      v.Spec.ApplyImmediately,
+		DBInstanceIdentifier:  aws.String(dbidentifier(v)),
+		PubliclyAccessible:    aws.Bool(v.Spec.PubliclyAccessible),
+		MultiAZ:               aws.Bool(v.Spec.MultiAZ),
+		BackupRetentionPeriod: aws.Int32(int32(v.Spec.BackupRetentionPeriod)),
+		DeletionProtection:    aws.Bool(v.Spec.DeleteProtection),
+	}
+	if v.Spec.Version != "" {
+		input.EngineVersion = aws.String(v.Spec.Version)
+	}
+	if v.Spec.StorageType != "" {
+		input.StorageType = aws.String(v.Spec.StorageType)
+	}
+	if v.Spec.Iops > 0 {
+		input.Iops = aws.Int32(int32(v.Spec.Iops))
+	}
+	return input
+}
+
 //DescribeInstancesResponse
 // describeNodeEC2Instance returns the AWS Metadata for the firt Node from the cluster
 func describeNodeEC2Instance(ctx context.Context, kubectl *kubernetes.Clientset, svc *ec2.Client) (*ec2.DescribeInstancesOutput, error) {
@@ -351,7 +404,7 @@ func getSubnets(ctx context.Context, nodeInfo *ec2.DescribeInstancesOutput, svc 
 		return nil, errors.Wrap(err, fmt.Sprintf("unable to describe subnet in VPC %v", *vpcID))
 	}
 	for _, sn := range subnets.Subnets {
-		if *sn.MapPublicIpOnLaunch == public {
+		if sn.MapPublicIpOnLaunch != nil && *sn.MapPublicIpOnLaunch == public {
 			result = append(result, *sn.SubnetId)
 		} else {
 			log.Printf("Skipping subnet %v since it's public state was %v and we were looking for %v\n", *sn.SubnetId, sn.MapPublicIpOnLaunch, public)

--- a/rds/rds_provider_test.go
+++ b/rds/rds_provider_test.go
@@ -191,3 +191,43 @@ func TestConvertSpecToDeleteInput_disabled(t *testing.T) {
 	assert.Equal(t, "mydb-myns-10202020202", *input.FinalDBSnapshotIdentifier)
 	assert.Equal(t, false, input.SkipFinalSnapshot)
 }
+
+func TestConvertSpecToModifyInput_withApplyImmediately(t *testing.T) {
+	input := convertSpecToModifyInput(&crd.Database{
+		Spec: crd.DatabaseSpec{
+			MaxAllocatedSize: 50,
+			Size:             21,
+			ApplyImmediately: true,
+			Class:            "db.t3.small",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "mydb",
+			Namespace: "myns",
+		},
+	})
+	assert.NotNil(t, input.DBInstanceIdentifier)
+	assert.Equal(t, true, input.ApplyImmediately)
+	assert.Equal(t, int32(50), *input.MaxAllocatedStorage)
+	assert.Equal(t, int32(21), *input.AllocatedStorage)
+	assert.Equal(t, "db.t3.small", *input.DBInstanceClass)
+}
+
+func TestConvertSpecToModifyInput_withoutApplyImmediately(t *testing.T) {
+	input := convertSpecToModifyInput(&crd.Database{
+		Spec: crd.DatabaseSpec{
+			MaxAllocatedSize: 50,
+			Size:             21,
+			ApplyImmediately: false,
+			Class:            "db.t3.small",
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "mydb",
+			Namespace: "myns",
+		},
+	})
+	assert.NotNil(t, input.DBInstanceIdentifier)
+	assert.Equal(t, false, input.ApplyImmediately)
+	assert.Equal(t, int32(50), *input.MaxAllocatedStorage)
+	assert.Equal(t, int32(21), *input.AllocatedStorage)
+	assert.Equal(t, "db.t3.small", *input.DBInstanceClass)
+}


### PR DESCRIPTION
This PR allows to restore the DB instance from an existing snapshot, if the snapshot with the given identifier does not exist, it'll try to create it using the given config. If the DB instance with the configured name already exists it will not try to restore it.

# How to test:
Config:
```
...
spec:
  class: db.t3.small
  engine: postgres
  dbname: mypgsql
  name: mypgsql
  ...
  DBSnapshotIdentifier: "mypgsql-default-1661462171045938588"
```

Simple output:
```
2022/08/26 12:29:51 Trying to find db instance mypgsql
2022/08/26 12:29:56 DB instance mypgsql not found trying to restore it from snapshot with id: mypgsql-default-1661462171045938588
2022/08/26 12:29:57 DB Snapshot with identifier mypgsql-default-1661462171045938588 was not found trying to create new DB instance with name: mypgsql
2022/08/26 12:29:58 Waiting for db instance mypgsql-default to become available
2022/08/26 12:33:34 DB instance mypgsql-default is now available
2022/08/26 12:33:35 Creating service 'mypgsql' for mypgsql-default.ctjkfvhtcpdu.us-east-1.rds.amazonaws.com
2022/08/26 12:33:35 Seems like we are running in a Kubernetes cluster!!
2022/08/26 12:33:35 New resource version of the DB mypgsql is 80480
2022/08/26 12:33:35 Creation of database mypgsql done
```